### PR TITLE
Update common.c - remove uncertain free() call for #5

### DIFF
--- a/common.c
+++ b/common.c
@@ -145,10 +145,10 @@ rawop_clear_list(head)
 		TAILQ_REMOVE(head, op, link);
 
 		if (op->data != NULL) {
-			d_printf(LOG_INFO, FNAME, "    freeing op data at %p", (void*)op->data);
+			d_printf(LOG_ERROR, FNAME, "    freeing op data at %p", (void*)op->data);
 			free(op->data);
 		}
-		free(op);	// Needed?
+		//free(op);	// Needed?
 	}
 	return;
 }


### PR DESCRIPTION
Memory corruption and/or coredump due to SIGBUS error.  Removing free(op); call appears to fix it. Note this only happens when using RAW options.

Also changed a log info to a log debug.