### PR TITLE
fix __unused macro

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -119,7 +119,7 @@ dhcp6_validate_key(struct keyinfo *key)
 }
 
 int
-dhcp6_calc_mac(char *buf, size_t len, int proto __unused, int alg,
+dhcp6_calc_mac(char *buf, size_t len, int proto __attribute__((__unused__)), int alg,
     size_t off, struct keyinfo *key)
 {
 	hmacmd5_t ctx;
@@ -148,7 +148,7 @@ dhcp6_calc_mac(char *buf, size_t len, int proto __unused, int alg,
 }
 
 int
-dhcp6_verify_mac(char *buf, ssize_t len, int proto __unused,
+dhcp6_verify_mac(char *buf, ssize_t len, int proto __attribute__((__unused__)),
     int alg, size_t off, struct keyinfo *key)
 {
 	hmacmd5_t ctx;


### PR DESCRIPTION
we tried to compile this dhcp6c Implementation using gcc 9 and gcc 6
```bash
./configure CFLAGS="-D _GNU_SOURCE"
make
```
However it did not compile with the following error:
```bash
expected »;«, »,« or »)« before »__unused
```
This should be fixed by replacing __unused by \_\_attribute\_\_((\_\_unused\_\_)). After this change it did compile fine