### PR TITLE
Log Prefix Info

### DIFF
--- a/common.c
+++ b/common.c
@@ -3306,12 +3306,15 @@ setloglevel(debuglevel)
 		switch(debuglevel) {
 		case 0:
 			setlogmask(LOG_UPTO(LOG_ERR));
+            debug_thresh = LOG_ERR;
 			break;
 		case 1:
 			setlogmask(LOG_UPTO(LOG_INFO));
+            debug_thresh = LOG_INFO;
 			break;
 		case 2:
 			setlogmask(LOG_UPTO(LOG_DEBUG));
+            debug_thresh = LOG_DEBUG;
 			break;
 		}
 	}
@@ -3348,7 +3351,10 @@ d_printf(int level, const char *fname, const char *fmt, ...)
 		    fname, printfname ? ": " : "",
 		    logbuf);
 	} else
-		syslog(level, "%s%s%s", fname, printfname ? ": " : "", logbuf);
+		if(debug_thresh == LOG_DEBUG) {
+            level = LOG_INFO;
+        }
+        syslog(level, "%s%s%s", fname, printfname ? ": " : "", logbuf);
 }
 
 int

--- a/prefixconf.c
+++ b/prefixconf.c
@@ -192,7 +192,7 @@ update_prefix(ia, pinfo, pifc, dhcpifp, ctlp, callback)
 	/* update the prefix according to pinfo */
 	sp->prefix.pltime = pinfo->pltime;
 	sp->prefix.vltime = pinfo->vltime;
-	d_printf(LOG_DEBUG, FNAME, "%s a prefix %s/%d pltime=%lu, vltime=%lu",
+	d_printf(LOG_INFO, FNAME, "%s a prefix %s/%d pltime=%lu, vltime=%lu",
 	    spcreate ? "create" : "update",
 	    in6addr2str(&pinfo->addr, 0), pinfo->plen,
 	    pinfo->pltime, pinfo->vltime);


### PR DESCRIPTION
Change the logging level to show prefix information in INFO logs rather than DEBUG logs