### PR TITLE
Remove command line interface options

### DIFF
--- a/config.c
+++ b/config.c
@@ -127,6 +127,7 @@ extern long long cf_refreshtime;
 extern char *configfilename;
 
 static struct keyinfo *find_keybyname(struct keyinfo *, char *);
+
 static int add_pd_pif(struct iapd_conf *, struct cf_list *);
 static int add_options(int, struct dhcp6_ifconf *, struct cf_list *);
 static int add_prefix(struct dhcp6_list *, const char *, int,
@@ -147,6 +148,9 @@ static struct pool_conf *create_pool(char *, struct dhcp6_range *);
 struct host_conf *find_dynamic_hostconf(struct duid *);
 static int in6_addr_cmp(struct in6_addr *, struct in6_addr *);
 static void in6_addr_inc(struct in6_addr *);
+
+
+
 
 /* a debug helper to complete someday if needed... or delete*/
 void list_cfl (char *tag,struct cf_namelist *head)
@@ -217,6 +221,10 @@ configure_interface(iflist)
 	struct dhcp6_ifconf *ifc;
 	char *cp;
 
+    /* xxx pointer back for use by dhcp6c interface names xxx */
+    ifnames = iflist;        
+    
+    
 	for (ifp = iflist; ifp; ifp = ifp->next) {
 		struct cf_list *cfl;
 

--- a/config.h
+++ b/config.h
@@ -310,6 +310,7 @@ extern struct dhcp6_list nispnamelist;
 extern struct dhcp6_list bcmcslist;
 extern struct dhcp6_list bcmcsnamelist;
 extern long long optrefreshtime;
+extern struct cf_namelist *ifnames;
 
 struct dhcp6_if *ifinit(char *);
 int ifreset(struct dhcp6_if *);

--- a/dhcp6c.c
+++ b/dhcp6c.c
@@ -195,7 +195,10 @@ main(int argc, char *argv[])
 	setloglevel(debug);
 
 	client6_init();
-
+    
+    /* Doing away with the need for command line interfaces */
+    /* We need to read the config file to get the names of the interfaces. */
+    
 	if (infreq_mode == 0 && (cfparse(conffile)) != 0) {
 		d_printf(LOG_ERR, FNAME, "failed to parse configuration file");
 		exit(1);
@@ -208,7 +211,12 @@ main(int argc, char *argv[])
 			exit(1);
 		}
     }
-
+    /* Read again to put stuff into the correct places now we have initialised the interfaces */
+    if (infreq_mode == 0 && (cfparse(conffile)) != 0) {
+		d_printf(LOG_ERR, FNAME, "failed to parse configuration file");
+		exit(1);
+	}
+    
 	if (foreground == 0 && infreq_mode == 0) {
 		if (daemon(0, 0) < 0)
 			err(1, "daemon");

--- a/dhcp6c.c
+++ b/dhcp6c.c
@@ -231,7 +231,7 @@ usage()
 {
 
 	fprintf(stderr, "usage: dhcp6c [-c configfile] [-dDfin] "
-	    "[-p pid-file] interface [interfaces...]\n");
+	    "[-p pid-file]\n");
 }
 
 /*------------------------------------------------------------*/


### PR DESCRIPTION
When adding or removing interfaces., dhcp6c would need to be shut down as the interfaces were part of the command line. The interfaces are also stored in the config file. Using the config file rather than the command line means dhcp6c no longer needs to be shutdown, a sighup causes a reset and re-read of the config.