### PR TITLE
PDINFO - All Interfaces

### DIFF
--- a/dhcp6.h
+++ b/dhcp6.h
@@ -128,6 +128,7 @@ struct dhcp6_prefix {		/* IA_PA */
 	uint32_t vltime;
 	struct in6_addr addr;
 	int plen;
+	char interface[5]; // Space for interface name i.e. igb0 + 1 for null terminator.
 };
 
 struct dhcp6_statefuladdr {	/* IA_NA */

--- a/prefixconf.c
+++ b/prefixconf.c
@@ -215,6 +215,7 @@ update_prefix(ia, pinfo, pifc, dhcpifp, ctlp, callback)
 				continue;
 			}
 
+		    sprintf(pinfo->interface,"%s",pif->ifname);
 			add_ifprefix(sp, pinfo, pif);
 		}
 	}


### PR DESCRIPTION
PDINFO is great, but if you have multiple LAN interfaces tracking it was only showing one of them. This update now puts the interface name and the prefix information for every interface that is tracking. It does so in the format of:

interface1.prefix1 interface2.prefix2 interface3.prefix3 ...

So for example igb1.2a02:xxxx:xxxxx:xx.../64 igb2.2a02:xxxx:xxxxx:xx.../64 ...

The forced commit addition increases the size of the var holding the interface to 5, as I forgot to account for the null terminator. duh!