### PR TITLE
Combine PDINFO per LAN and SERVER env

### DIFF
--- a/dhcp6.h
+++ b/dhcp6.h
@@ -128,6 +128,7 @@ struct dhcp6_prefix {		/* IA_PA */
 	uint32_t vltime;
 	struct in6_addr addr;
 	int plen;
+	char interface[5]; // Space for interface name i.e. igb0 + 1 for null terminator.
 };
 
 struct dhcp6_statefuladdr {	/* IA_NA */

--- a/dhcp6c.h
+++ b/dhcp6c.h
@@ -39,6 +39,6 @@ struct dhcp6_timer *client6_timo(void *);
 int client6_start(struct dhcp6_if *);
 void client6_send(struct dhcp6_event *);
 
-int client6_script(char *, int, struct dhcp6_optinfo *);
+int client6_script(char *, int, struct dhcp6_optinfo *, char *);
 
 #endif

--- a/prefixconf.c
+++ b/prefixconf.c
@@ -215,6 +215,7 @@ update_prefix(ia, pinfo, pifc, dhcpifp, ctlp, callback)
 				continue;
 			}
 
+		    sprintf(pinfo->interface,"%s",pif->ifname);
 			add_ifprefix(sp, pinfo, pif);
 		}
 	}


### PR DESCRIPTION
Single PR containing mods to allow PD Info per LAN and SERVER env variable for users who do not get a routerv6 info from rtsold. Replaces #22 and #23 .

PDINFO is great, but if you have multiple LAN interfaces tracking it was only showing one of them. This update now puts the interface name and the prefix information for every interface that is tracking. It does so in the format of:

interface1.prefix1 interface2.prefix2 interface3.prefix3 ...

So for example igb1.2a02:xxxx:xxxxx:xx.../64 igb2.2a02:xxxx:xxxxx:xx.../64 ...

On receipt of a REQUEST reply this commit will cause dhcp6c to create a new ENVVAR 'SERVER' that contains the address of the server that gave the lease - this is usually the gateway, I think Franco wanted this to address the issue where RTSOLD does not receive anything. The server info is returned in this form:

fe80::20e:c4ff:fed2:8142

I have not deleted the older PRs as they have links to the changes required in interfaces.inc etc.