### PR TITLE
Enable SLA-LEN autocorrect

### DIFF
--- a/common.h
+++ b/common.h
@@ -124,7 +124,7 @@ extern int foreground;
 extern int debug_thresh;
 extern char *device;
 extern int opt_norelease;
-
+extern int opt_auto;
 /* search option for dhcp6_find_listval() */
 #define MATCHLIST_PREFIXLEN 0x1
 

--- a/dhcp6c.c
+++ b/dhcp6c.c
@@ -103,7 +103,7 @@ static int ctldigestlen;
 static int infreq_mode = 0;
 
 int opt_norelease;
-
+int opt_auto;
 static void usage(void);
 static void client6_init(void);
 static void client6_startall(int);
@@ -157,7 +157,7 @@ main(int argc, char *argv[])
 	else
 		progname++;
 
-	while ((ch = getopt(argc, argv, "c:dDfinp:")) != -1) {
+	while ((ch = getopt(argc, argv, "c:adDfinp:")) != -1) {
 		switch (ch) {
 		case 'c':
 			conffile = optarg;
@@ -173,6 +173,9 @@ main(int argc, char *argv[])
 			break;
 		case 'i':
 			infreq_mode = 1;
+			break;
+   case 'a':
+			opt_auto = 1;
 			break;
 		case 'n':
 			opt_norelease = 1;

--- a/prefixconf.c
+++ b/prefixconf.c
@@ -465,8 +465,16 @@ add_ifprefix(siteprefix, prefix, pconf)
 		d_printf(LOG_INFO, FNAME,
 			"invalid prefix length %d + %d + %d",
 			prefix->plen, pconf->sla_len, pconf->ifid_len);
+   if(!opt_auto) {
 		goto bad;
+   }
 	}
+
+  if( prefix->plen + pconf->sla_len != 64 ) {
+    d_printf(LOG_INFO, FNAME,"Prefix obtained (%d) does not match prefix SLA (%d) ( requested prefix %d ), auto changing to match obtained prefix",prefix->plen, pconf->sla_len, 64-pconf->sla_len);
+    pconf->sla_len = 64-prefix->plen;
+    ifpfx->plen = 64;
+  }
 
 	/* copy prefix and SLA ID */
 	a = &ifpfx->paddr.sin6_addr;


### PR DESCRIPTION
Make dhcp6c do the work for us when the SLA-LEN given by the user does not match the prefix obtained.