### PR TITLE
Initial attempt at adding multiple pd to scripts

### DIFF
--- a/config.h
+++ b/config.h
@@ -181,6 +181,8 @@ struct prefix_ifconf {
 	int ifid_len;		/* interface ID length in bits */
 	int ifid_type;		/* EUI-64 and manual (unused?) */
 	char ifid[16];		/* Interface ID, up to 128bits */
+
+	struct sockaddr_in6 *ifaddr;
 };
 #define IFID_LEN_DEFAULT 64
 #define SLA_LEN_DEFAULT 16

--- a/dhcp6c.c
+++ b/dhcp6c.c
@@ -478,7 +478,7 @@ check_exit(void)
 			return;
 	}
 	for (ifp = dhcp6_if; ifp; ifp = ifp->next)
-		client6_script(ifp->scriptpath, DHCP6S_EXIT, NULL);
+		client6_script(ifp->scriptpath, DHCP6S_EXIT, NULL, ifp);
 
 	/* We have no existing event.  Do exit. */
 	d_printf(LOG_INFO, FNAME, "exiting");
@@ -1737,7 +1737,7 @@ client6_recvreply(struct dhcp6_if *ifp, struct dhcp6 *dh6,
 	 * Call the configuration script, if specified, to handle various
 	 * configuration parameters.
 	 */
-	client6_script(ifp->scriptpath, state, optinfo);
+	client6_script(ifp->scriptpath, state, optinfo, ifp);
 
 	dhcp6_remove_event(ev);
 

--- a/dhcp6c.h
+++ b/dhcp6c.h
@@ -39,6 +39,6 @@ struct dhcp6_timer *client6_timo(void *);
 int client6_start(struct dhcp6_if *);
 void client6_send(struct dhcp6_event *);
 
-int client6_script(char *, int, struct dhcp6_optinfo *);
+int client6_script(char *, int, struct dhcp6_optinfo *, struct dhcp6_if *);
 
 #endif

--- a/dhcp6c_script.c
+++ b/dhcp6c_script.c
@@ -92,9 +92,9 @@ client6_script(scriptpath, state, optinfo, ifp)
 	char reason[32];
 	/* need space for 32 + 7 : + 1 / + 1-3 prefixlen,
 	 * leave room for scope for %scope even though unused */
-	char prefixinfo[64];
+	static char prefixinfo[64];
 	/* enuough space for ~1.5* a /56 worth of /64 ifs of 8 chars + sla_len:id */
-	char prefixif[4096];
+	static char prefixif[8192];
 	int prefixcount = 0;
 	struct dhcp6_listval *v;
 	struct dhcp6_event ev;
@@ -244,9 +244,10 @@ setenv:
 				for (pif = TAILQ_FIRST(&iapdc->iapd_pif_list); pif && if_left > 1;
 						pif = TAILQ_NEXT(pif, link)) {
 					/* finally the configured if name */
-					ret = snprintf(if_next, if_left, "%c%s:%x:%x",
+					ret = snprintf(if_next, if_left, "%c%s,%s",
 						if_count ? ' ' : '=',
-						pif->ifname, pif->sla_len, pif->sla_id);
+						pif->ifname, pif->ifaddr
+						? addr2str((struct sockaddr *)pif->ifaddr) : "");
 					if_left -= ret;
 					if_next += ret;
 					if_count += 1;

--- a/dhcp6c_script.c
+++ b/dhcp6c_script.c
@@ -74,13 +74,14 @@ static char bcmcsserver_str[] = "new_bcmcs_servers";
 static char bcmcsname_str[] = "new_bcmcs_name";
 static char raw_dhcp_option_str[] = "raw_dhcp_option";
 
-int client6_script(char *, int, struct dhcp6_optinfo *);
+int client6_script(char *, int, struct dhcp6_optinfo *, struct dhcp6_if *);
 
 int
-client6_script(scriptpath, state, optinfo)
+client6_script(scriptpath, state, optinfo, ifp)
 	char *scriptpath;
 	int state;
 	struct dhcp6_optinfo *optinfo;
+	struct dhcp6_if *ifp;
 {
 	int i, dnsservers, ntpservers, dnsnamelen, envc, elen, ret = 0;
 	int sipservers, sipnamelen;
@@ -89,12 +90,19 @@ client6_script(scriptpath, state, optinfo)
 	int bcmcsservers, bcmcsnamelen;
 	char **envp, *s;
 	char reason[32];
-	char prefixinfo[32];
+	/* need space for 32 + 7 : + 1 / + 1-3 prefixlen,
+	 * leave room for scope for %scope even though unused */
+	char prefixinfo[64];
+	/* enuough space for ~1.5* a /56 worth of /64 ifs of 8 chars + sla_len:id */
+	char prefixif[4096];
+	int prefixcount = 0;
 	struct dhcp6_listval *v;
 	struct dhcp6_event ev;
 	struct rawoption *rawop;
 	pid_t pid, wpid;
 	struct dhcp6_listval *iav, *siav;
+	struct iapd_conf *iapdc;
+	struct prefix_ifconf *pif;
 
 	/* if a script is not specified, do nothing */
 	if (scriptpath == NULL || strlen(scriptpath) == 0)
@@ -115,7 +123,7 @@ client6_script(scriptpath, state, optinfo)
 	nispnamelen = 0;
 	bcmcsservers = 0;
 	bcmcsnamelen = 0;
-	envc = 3;     /* we at least include the reason, prefix and the terminator */
+	envc = 5;     /* we at least include the reason, prefix count, duids, and the terminator */
 	if (state == DHCP6S_EXIT)
 		goto setenv;
 
@@ -167,6 +175,15 @@ client6_script(scriptpath, state, optinfo)
 	}
 	envc += bcmcsnamelen ? 1 : 0;
 
+	/* count the number of prefix delegations */
+	for (iav = TAILQ_FIRST(&optinfo->iapd_list); iav; iav = TAILQ_NEXT(iav, link)) {
+		for (siav = TAILQ_FIRST(&iav->sublist); siav; siav = TAILQ_NEXT(siav, link)) {
+			if (siav->type == DHCP6_LISTVAL_PREFIX6) {
+				envc += 2; /* prefix and interface vars */
+			}
+		}
+	}
+
 setenv:
 	/* allocate an environments array */
 	if ((envp = malloc(sizeof (char *) * envc)) == NULL) {
@@ -192,22 +209,90 @@ setenv:
 	if (state == DHCP6S_EXIT)
 		goto launch;
 
-	/* prefix delegation */
+	/* prefix delegations */
 	for (iav = TAILQ_FIRST(&optinfo->iapd_list); iav; iav = TAILQ_NEXT(iav, link)) {
+		if ((iapdc = (struct iapd_conf *)find_iaconf(
+				&ifp->iaconf_list, IATYPE_PD, iav->val_ia.iaid)) == NULL) {
+			continue;
+		}
 		for (siav = TAILQ_FIRST(&iav->sublist); siav; siav = TAILQ_NEXT(siav, link)) {
+			size_t if_left = sizeof(prefixif);
+			char *if_next = prefixif;
+			size_t ret = 0;
+			unsigned int if_count = 0;
 			if (siav->type == DHCP6_LISTVAL_PREFIX6) {
-				snprintf(prefixinfo, sizeof(prefixinfo),
-				    "PDINFO=%s/%d",
-				    in6addr2str(&siav->val_prefix6.addr, 0),
-				    siav->val_prefix6.plen);
+				/* set first to PDINFO/PDINT */
+				if (!prefixcount) {
+					snprintf(prefixinfo, sizeof(prefixinfo),
+							"PDINFO=%s/%d",
+							in6addr2str(&siav->val_prefix6.addr, 0),
+							siav->val_prefix6.plen);
+					ret = strlcpy(prefixif, "PDIF", if_left);
+				} else {
+					snprintf(prefixinfo, sizeof(prefixinfo),
+							"PDINFO%d=%s/%d",
+								prefixcount,
+							in6addr2str(&siav->val_prefix6.addr, 0),
+							siav->val_prefix6.plen);
+					ret = snprintf(prefixif, if_left,
+							"PDIF%d", prefixcount);
+				}
+
+				if_next = prefixif + ret;
+				if_left -= ret;
+
+				for (pif = TAILQ_FIRST(&iapdc->iapd_pif_list); pif && if_left > 1;
+						pif = TAILQ_NEXT(pif, link)) {
+					/* finally the configured if name */
+					ret = snprintf(if_next, if_left, "%c%s:%x:%x",
+						if_count ? ' ' : '=',
+						pif->ifname, pif->sla_len, pif->sla_id);
+					if_left -= ret;
+					if_next += ret;
+					if_count += 1;
+				}
+
 				if ((envp[i++] = strdup(prefixinfo)) == NULL) {
 					d_printf(LOG_NOTICE, FNAME, "failed to allocate prefixinfo strings");
 					ret = -1;
 					goto clean;
 				}
+
+				if (if_count) {
+					if ((envp[i++] = strdup(prefixif)) == NULL) {
+						d_printf(LOG_NOTICE, FNAME, "failed to allocate prefixif strings");
+						ret = -1;
+						goto clean;
+					}
+				}
+
+				prefixcount += 1;
 			}
 		}
 	}
+
+	snprintf(prefixinfo, sizeof(prefixinfo), "PDCOUNT=%d", prefixcount);
+	if ((envp[i++] = strdup(prefixinfo)) == NULL) {
+		d_printf(LOG_NOTICE, FNAME, "failed to allocate prefixinfo strings");
+		ret = -1;
+		goto clean;
+	}
+
+	elen = sizeof("xx:") * 128 + sizeof("...") + sizeof("CDUID=");
+	if ((s = envp[i++] = malloc(elen)) == NULL) {
+		d_printf(LOG_NOTICE, FNAME, "failed to allocate duid strings");
+		ret = -1;
+		goto clean;
+	}
+	snprintf(s, elen, "CDUID=%s", duidstr(&ifp->duid));
+
+	elen = sizeof("xx:") * 128 + sizeof("...") + sizeof("SDUID=");
+	if ((s = envp[i++] = malloc(elen)) == NULL) {
+		d_printf(LOG_NOTICE, FNAME, "failed to allocate duid strings");
+		ret = -1;
+		goto clean;
+	}
+	snprintf(s, elen, "SDUID=%s", duidstr(&optinfo->serverID));
 
 	/* "var=addr1 addr2 ... addrN" + null char for termination */
 	if (dnsservers) {

--- a/prefixconf.c
+++ b/prefixconf.c
@@ -113,7 +113,7 @@ static void renew_data_free(struct dhcp6_eventdata *);
 
 static struct dhcp6_timer *siteprefix_timo(void *);
 
-static int add_ifprefix(struct siteprefix *,
+static struct sockaddr_in6 *add_ifprefix(struct siteprefix *,
     struct dhcp6_prefix *, struct prefix_ifconf *);
 
 static int pd_ifaddrconf(ifaddrconf_cmd_t, struct dhcp6_ifprefix *ifpfx);
@@ -215,7 +215,7 @@ update_prefix(ia, pinfo, pifc, dhcpifp, ctlp, callback)
 				continue;
 			}
 
-			add_ifprefix(sp, pinfo, pif);
+			pif->ifaddr = add_ifprefix(sp, pinfo, pif);
 		}
 	}
 
@@ -425,7 +425,7 @@ siteprefix_timo(arg)
 	return (NULL);
 }
 
-static int
+static struct sockaddr_in6 *
 add_ifprefix(siteprefix, prefix, pconf)
 	struct siteprefix *siteprefix;
 	struct dhcp6_prefix *prefix;
@@ -440,7 +440,7 @@ add_ifprefix(siteprefix, prefix, pconf)
 	if ((ifpfx = malloc(sizeof(*ifpfx))) == NULL) {
 		d_printf(LOG_NOTICE, FNAME,
 		    "failed to allocate memory for ifprefix");
-		return (-1);
+		goto bad;
 	}
 	memset(ifpfx, 0, sizeof(*ifpfx));
 
@@ -492,12 +492,12 @@ add_ifprefix(siteprefix, prefix, pconf)
 
 	TAILQ_INSERT_TAIL(&siteprefix->ifprefix_list, ifpfx, plink);
 
-	return (0);
+	return &ifpfx->ifaddr;
 
   bad:
 	if (ifpfx)
 		free(ifpfx);
-	return (-1);
+	return NULL;
 }
 
 #ifndef ND6_INFINITE_LIFETIME


### PR DESCRIPTION
This adds all pds besides zero with their identifier as a base10 int after
PDINFO in the variable name, a PDCOUNT variable, as well as related PDIF with a
space separated list of {interface}:{sla_len}:{sla_id} following same naming as
PDINFO, a CDUID (client) and SDUID (server) so that this information can be
passed to other systems.

For example where the second pd has no interfaces:
```
SDUID=<serverDUID>
CDUID=<interfaceDUID>
PDINFO=1111:1111:1111::/56
PDIF=vlan1:8:0 vlan2:8:2 vlan3:8:3
PDINFO1=1111:1111:1112::/56
PDINFO2=1111:1111:1113::/56
PDIF2=vlan4:8:0
PDCOUNT=3
```

This addresses (and then some) #19.