### PR TITLE
Fix IPv6 reconfig errors with Vodafone Germany in NRW

### DIFF
--- a/common.c
+++ b/common.c
@@ -1777,10 +1777,9 @@ dhcp6_get_options(p, ep, optinfo)
 				    optinfo->delayedauth_offset,
 				    optinfo->delayedauth_realmlen);
 				break;
-#ifdef notyet
 			case DHCP6_AUTHPROTO_RECONFIG:
+				d_printf(LOG_DEBUG, FNAME, "  ignoring not implemented authentication protocol: reconfig");
 				break;
-#endif
 			/* XXX */
 			case 0:
 				// Discard auth
@@ -1793,7 +1792,7 @@ dhcp6_get_options(p, ep, optinfo)
 			default:
 				d_printf(LOG_INFO, FNAME,
 				    "unsupported authentication protocol: %d",
-				    *cp);
+				    optinfo->authproto);
 				goto fail;
 			}
 			break;


### PR DESCRIPTION
Vodafone Germany changed some parts of their cable network in Germany (most recently in NRW). Changes to their DHCPv6 server made receiving v6 prefixes and addresses impossible. This fix skips the missing implementation in DHCP6_AUTHPROTO_RECONFIG and enables receiving addresses in my testing. Merging would very much help out some users in Germany. Contact me on this if needed.

Disclaimer: I did not author these changes, I just ported them from [here](https://www.reddit.com/r/fortinet/comments/tqx29q/comment/i2r2n7d/?utm_source=share&utm_medium=web2x&context=3) where somebody posted a patch for the Debian version of wide-dhcpv6.