### PR TITLE
Fix "bad address" error with multiple prefix delegations

### DIFF
--- a/dhcp6c_script.c
+++ b/dhcp6c_script.c
@@ -205,10 +205,12 @@ setenv:
 					ret = -1;
 					goto clean;
 				}
+				goto servers;
 			}
 		}
 	}
 
+servers:
 	/* "var=addr1 addr2 ... addrN" + null char for termination */
 	if (dnsservers) {
 		elen = sizeof (dnsserver_str) +


### PR DESCRIPTION
`dhcp6c_script.c` does not allocate enough space in `envp` for multiple PDINFO env vars:
https://github.com/opnsense/dhcp6c/blob/cff2641237596c28d05dd8d4b591e5b508d93078/dhcp6c_script.c#L118
https://github.com/opnsense/dhcp6c/blob/cff2641237596c28d05dd8d4b591e5b508d93078/dhcp6c_script.c#L172
https://github.com/opnsense/dhcp6c/blob/cff2641237596c28d05dd8d4b591e5b508d93078/dhcp6c_script.c#L196-L200

This causes EFAULT ("bad address") errors from `execve`, reported here:
https://forum.opnsense.org/index.php?topic=25211.0

This PR fixes the error by passing a single value (the first PD) for the PDINFO env var. Longer-term, this issue may be better addressed by https://github.com/opnsense/dhcp6c/pull/28, which would cleanly pass multiple PDs to the script.

I suspect this fix will improve stability for AT&T Fiber users who allocate multiple IPv6 prefix delegations with a configuration file override. This crash can be covered up when the script is reinvoked, but after allocating 4 PDs, I consistently lost one LAN address on reboot. I noticed it inconsistently at 3 PDs.