### PR TITLE
Fix (revert) ia na renew

### DIFF
--- a/addrconf.c
+++ b/addrconf.c
@@ -166,9 +166,9 @@ update_address(struct ia *ia, struct dhcp6_statefuladdr *addr,
 	sa->addr.pltime = addr->pltime;
 	sa->addr.vltime = addr->vltime;
 	sa->dhcpif = dhcpifp;
-	d_printf(LOG_DEBUG, FNAME, "%s an address %s pltime=%lu, vltime=%lu",
+	d_printf(LOG_DEBUG, FNAME, "%s an address %s pltime=%u, vltime=%u",
 	    sacreate ? "create" : "update",
-	    in6addr2str(&addr->addr, 0), addr->pltime, addr->vltime);
+	    in6addr2str(&addr->addr, 0), (unsigned int)addr->pltime, (unsigned int)addr->vltime);
 
 	if ((sa->addr.vltime != 0) && sacreate)
 		if (na_ifaddrconf(IFADDRCONF_ADD, sa) < 0)

--- a/addrconf.c
+++ b/addrconf.c
@@ -168,7 +168,8 @@ update_address(struct ia *ia, struct dhcp6_statefuladdr *addr,
 	sa->dhcpif = dhcpifp;
 	d_printf(LOG_DEBUG, FNAME, "%s an address %s pltime=%u, vltime=%u",
 	    sacreate ? "create" : "update",
-	    in6addr2str(&addr->addr, 0), (unsigned int)addr->pltime, (unsigned int)addr->vltime);
+	    in6addr2str(&addr->addr, 0), (unsigned int)addr->pltime,
+	    (unsigned int)addr->vltime);
 
 	if ((sa->addr.vltime != 0) && sacreate)
 		if (na_ifaddrconf(IFADDRCONF_ADD, sa) < 0)

--- a/common.c
+++ b/common.c
@@ -3438,7 +3438,8 @@ ifaddrconf(cmd, ifname, addr, plen, pltime, vltime)
 	memset(&req, 0, sizeof(req));
 #ifdef __KAME__
 	req.ifra_addr = *addr;
-	memcpy(req.ifra_name, ifname, sizeof(req.ifra_name));
+	memset(req.ifra_name, 0, sizeof(req.ifra_name));
+	strncpy(req.ifra_name, ifname, IFNAMSIZ - 1);
 	(void)sa6_plen2mask(&req.ifra_prefixmask, plen);
 	/* XXX: should lifetimes be calculated based on the lease duration? */
 	req.ifra_lifetime.ia6t_vltime = vltime;

--- a/common.c
+++ b/common.c
@@ -3438,8 +3438,7 @@ ifaddrconf(cmd, ifname, addr, plen, pltime, vltime)
 	memset(&req, 0, sizeof(req));
 #ifdef __KAME__
 	req.ifra_addr = *addr;
-	memset(req.ifra_name, 0, sizeof(req.ifra_name));
-	strncpy(req.ifra_name, ifname, IFNAMSIZ - 1);
+	strlcpy(req.ifra_name, ifname, sizeof(req.ifra_name));
 	(void)sa6_plen2mask(&req.ifra_prefixmask, plen);
 	/* XXX: should lifetimes be calculated based on the lease duration? */
 	req.ifra_lifetime.ia6t_vltime = vltime;


### PR DESCRIPTION
Fixes an issue reported in the forums here:-

https://forum.opnsense.org/index.php?topic=41160

Since this is reverting a commit from someone far more experienced than I am, I thought it best to illustrate the problem with an example:-

1) Set up a DHCPv6 server with the following config:-

```
option dhcp6.rapid-commit;

preferred-lifetime 60;
default-lease-time 120;
max-lease-time 120;
log-facility local7;
one-lease-per-client true;
deny duplicates;
ping-check true;
update-conflict-detection false;
authoritative;
option dhcp-renewal-time 60;
option dhcp-rebinding-time 96;
dhcpv6-set-tee-times true;

subnet6 <current_net>::/64 {
  range6 <current_net>::1000 <current_net>::2000;
  option dhcp6.name-servers <current_net>::1;
}

ddns-update-style none;
```

2) Run dhcp6c with the following config (i.e. just request an address):-

 ```
interface vtnet0 {
  send ia-na 0; # request stateful address
  request domain-name-servers;
  request domain-name;
  script "/var/etc/dhcp6c_wan_script.sh"; # we'd like some nameservers please
};
id-assoc na 0 { };
```

When the application starts, an address is assigned and can be examined with `ifconfig -L` :-

```
$ ifconfig -L vtnet0
vtnet0: flags=8863<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
. . .
	inet6 <current_net>::2000 prefixlen 128 pltime 45 vltime 105
. . .
```

When the counter reaches zero, the application logs a renew as expected. However, the address is now deprecated:-

```
$ ifconfig -L vtnet0
vtnet0: flags=8863<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
. . .
	inet6 <current_net>::2000 prefixlen 128 deprecated pltime 0 vltime 57
. . .
```