### PR TITLE
Add lockfile (-l) command line parameter.

### DIFF
--- a/dhcp6c.8
+++ b/dhcp6c.8
@@ -37,6 +37,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl c Ar configfile
+.Op Fl l Ar lockfile
 .Op Fl Ddfint
 .Op Fl p Ar pid-file
 .Op Ar interfaces...
@@ -89,6 +90,11 @@ is terminated.  (suits for a use in shell-script etc).
 Since the configuration is internally generated, you cannot provide a configuration in this mode.  If you want to have different actions for the stateless DHCPv6 information, you should write an appropriate configuration and invoke
 .Nm
 without this option.
+.It Fl l Ar lockfile
+Obtain an exclusive lock on
+.Ar lockfile
+before operation to avoid concurrent runs of the DHCPv6 client.  The lock
+is held until the process exits.
 .It Fl n
 Prevent Release message from being sent to DHCPv6 server when
 .Nm

--- a/dhcp6c.c
+++ b/dhcp6c.c
@@ -149,8 +149,9 @@ static char **saved_cli_if;
 int
 main(int argc, char *argv[])
 {
-	int ch, pid;
+	int ch, lock_fd, pid;
 	char *progname;
+	const char *lockfile = NULL;
 	FILE *pidfp;
 	struct cf_namelist *ifnamep;
 
@@ -159,7 +160,7 @@ main(int argc, char *argv[])
 	else
 		progname++;
 
-	while ((ch = getopt(argc, argv, "c:dDfinp:t")) != -1) {
+	while ((ch = getopt(argc, argv, "c:dDfil:np:t")) != -1) {
 		switch (ch) {
 		case 'c':
 			conffile = optarg;
@@ -175,6 +176,9 @@ main(int argc, char *argv[])
 			break;
 		case 'i':
 			infreq_mode = 1;
+			break;
+		case 'l':
+			lockfile = optarg;
 			break;
 		case 'n':
 			opt_norelease = 1;
@@ -198,6 +202,17 @@ main(int argc, char *argv[])
 		openlog(progname, LOG_NDELAY|LOG_PID, LOG_DAEMON);
 
 	setloglevel(debug);
+
+	if (lockfile != NULL) {
+		lock_fd = open(lockfile, O_RDWR|O_CREAT, 0666);
+		if (lock_fd < 0)
+			err(1, "cannot open lockfile %s", lockfile);
+
+		if (flock(lock_fd, LOCK_EX|LOCK_NB) != 0) {
+			info_printf("cannot obtain exclusive lock on %s (%s)", lockfile, strerror(errno));
+			exit(0);
+		}
+	}
 
 	client6_init();
 
@@ -246,7 +261,7 @@ main(int argc, char *argv[])
 static void
 usage(void)
 {
-	fprintf(stderr, "usage: dhcp6c [-c configfile] [-dDfint] "
+	fprintf(stderr, "usage: dhcp6c [-c configfile] [-l lockfile] [-dDfint] "
 	    "[-p pid-file] [interfaces...]\n");
 }
 


### PR DESCRIPTION
This is needed to avoid concurrent runs of dhcp6c which can lead to IPv6 connectivity problems.

Related to https://github.com/opnsense/core/pull/8467 and https://github.com/opnsense/core/issues/8431