### PR TITLE
Expose raw options to script

### DIFF
--- a/common.c
+++ b/common.c
@@ -1909,9 +1909,28 @@ dhcp6_get_options(struct dhcp6opt *p, struct dhcp6opt *ep,
 
 		default:
 			/* no option specific behavior */
-			d_printf(LOG_INFO, FNAME,
-			    "unknown or unexpected DHCP6 option %s, len %d",
-			    dhcp6optstr(opt), optlen);
+			struct rawoption *op;
+			if ((op = malloc(sizeof(*op))) == NULL) {
+				d_printf(LOG_ERR, FNAME,
+					"failed to allocate memory for a new raw option");
+				return(-1);
+			}
+
+			memset(op, 0, sizeof(*op));
+
+			op->opnum = opt;
+			op->datalen = optlen;
+
+			/* copy data */
+			if ((op->data = malloc(op->datalen)) == NULL) {
+				d_printf(LOG_ERR, FNAME,
+				    "failed to allocate memory for new raw option data");
+				return(-1);
+			}
+			memcpy(op->data, cp, op->datalen);
+
+			TAILQ_INSERT_TAIL(&optinfo->rawops, op, link);
+
 			break;
 		}
 	}

--- a/dhcp6c_script.c
+++ b/dhcp6c_script.c
@@ -456,7 +456,7 @@ setenv:
 			val[0] = hex[(rawop->data[o]>>4) & 0x0F];
 			val[1] = hex[(rawop->data[o]   ) & 0x0F];
 			val[2] = 0x00;
-			strlcat(s, val, 1);
+			strlcat(s, val, elen);
 		}
 		free(val);
 	}


### PR DESCRIPTION
Reading the code I found out there was already support for sending custom DHCPv6 options as env vars to a custom script, but the source variable (optinfo->rawops) is never updated with the options received. As a result, the script never receives those options.

I tried to fix it with this patch.
I've been testing it on my primary OPNsense router since mid-July with success so far.