### PR TITLE
dhcp6c_script: allocate correct length for name variables

### DIFF
--- a/dhcp6c_script.c
+++ b/dhcp6c_script.c
@@ -93,7 +93,7 @@
 	struct dhcp6_listval *v; \
 	TAILQ_FOREACH(v, &optinfo->lname##_list, link) { \
 		/* one space separator plus address length or as is */ \
-		lname##_len += 1 + ((lip) ? INET6_ADDRSTRLEN : lname##_len); \
+		lname##_len += 1 + ((lip) ? INET6_ADDRSTRLEN : v->val_vbuf.dv_len); \
 	} \
 	envc += lname##_len ? 1 : 0; \
 } while (0)


### PR DESCRIPTION
Basically, for variables using the COUNT_NAME macro, the buffers were always too small. I noticed this while trying to use the variable `new_aftr_name`. DHCP received the value `aftr09.netcologne.de` for it, but the environment variable only contained `af`.

That's because COUNT_NAME only does +1 on the length for name variables without every considering the actual length. RENDER_NAME allocates:
- sizeof(lstr): length of the variable name including a null terminator
- +2: for the equal sign and an optional space delimiter.
- lname##_len: always 1 before this commit

So when there was only one name in the list, 2 bytes were available to the value itself due to the unused space delimiter.

This commit fixes that, by using the actual value length in the COUNT_NAME macro.